### PR TITLE
Fix web download to also check the curl status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mod.json
 *.psd
 *.~cpp
 *.~hpp
+vcpkg_installed/

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -33,9 +33,9 @@ namespace SongDetailsCache {
                 /// @brief http content
                 std::string content;
 
-                /// @brief checks for httpCode 200 and curlStatus CURLE_OK
-                operator bool() {
-                    return httpCode == 200 && curlStatus == CURLE_OK;
+                /// @brief checks for httpCode 200 - 299 and curlStatus CURLE_OK
+                inline constexpr operator bool() const noexcept {
+                    return httpCode >= 200 && httpCode < 300 && curlStatus == CURLE_OK;
                 }
             };
 

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -7,6 +7,9 @@
 #include <future>
 #include <unordered_map>
 
+#include "libcurl/shared/curl.h"
+#include "libcurl/shared/easy.h"
+
 namespace SongDetailsCache {
     class HexUtil {
         public:
@@ -21,10 +24,26 @@ namespace SongDetailsCache {
     class WebUtil {
         public:
             struct WebResponse {
+                /// @brief http response code
                 long httpCode;
+                /// @brief curl status code after curl_easy_perform
+                CURLcode curlStatus;
+                /// @brief http headers
                 std::string headers;
+                /// @brief http content
                 std::string content;
+
+                /// @brief checks for httpCode 200 and curlStatus CURLE_OK
+                operator bool() {
+                    return httpCode == 200 && curlStatus == CURLE_OK;
+                }
             };
+
+            /// @brief performs an async get request
+            /// @param url the url to GET
+            /// @param timeout timeout for the request
+            /// @param headers headers to pass along with the request
+            /// @return async future to await for the response
             static std::future<WebResponse> GetAsync(std::string_view url, uint32_t timeout, const std::unordered_map<std::string, std::string>& headers);
         private:
             static WebResponse GetAsync_internal(std::string_view url, uint32_t timeout, const std::unordered_map<std::string, std::string>& headers);

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -2,8 +2,8 @@
 #include <string_view>
 #include "paper/shared/logger.hpp"
 
-#define INFO(...) Paper::Logger::fmtLog<Paper::LogLevel::INF>(__VA_ARGS__)
-#define ERROR(...) Paper::Logger::fmtLog<Paper::LogLevel::ERR>(__VA_ARGS__)
-#define CRITICAL(...) Paper::Logger::fmtLog<Paper::LogLevel::ERR>(__VA_ARGS__)
-#define DEBUG(...) Paper::Logger::fmtLog<Paper::LogLevel::DBG>(__VA_ARGS__)
-#define WARNING(...) Paper::Logger::fmtLog<Paper::LogLevel::WRN>(__VA_ARGS__)
+#define INFO(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::INF>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
+#define ERROR(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::ERR>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
+#define CRITICAL(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::ERR>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
+#define DEBUG(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::DBG>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
+#define WARNING(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::WRN>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -2,8 +2,8 @@
 #include <string_view>
 #include "paper/shared/logger.hpp"
 
-#define INFO(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::INF>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
-#define ERROR(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::ERR>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
-#define CRITICAL(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::ERR>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
-#define DEBUG(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::DBG>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
-#define WARNING(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::WRN>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
+#define INFO(str, ...) Paper::Logger::fmtLog<Paper::LogLevel::INF>(str __VA_OPT__(, __VA_ARGS__))
+#define ERROR(str, ...) Paper::Logger::fmtLog<Paper::LogLevel::ERR>(str __VA_OPT__(, __VA_ARGS__))
+#define CRITICAL(str, ...) Paper::Logger::fmtLog<Paper::LogLevel::ERR>(str __VA_OPT__(, __VA_ARGS__))
+#define DEBUG(str, ...) Paper::Logger::fmtLog<Paper::LogLevel::DBG>(str __VA_OPT__(, __VA_ARGS__))
+#define WARNING(str, ...) Paper::Logger::fmtLog<Paper::LogLevel::WRN>(str __VA_OPT__(, __VA_ARGS__))

--- a/qpm.json
+++ b/qpm.json
@@ -18,7 +18,7 @@
     },
     {
       "id": "beatsaber-hook",
-      "versionRange": "*",
+      "versionRange": "^3.14.0",
       "additionalData": {}
     },
     {

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -42,19 +42,19 @@
         "build": [
           "pwsh ./scripts/build.ps1"
         ],
-        "log": [
-          "pwsh ./scripts/log.ps1"
-        ],
-        "clean": [
-          "pwsh ./scripts/build.ps1 -clean"
+        "copy": [
+          "pwsh ./scripts/copy.ps1"
         ],
         "qmod": [
           "pwsh ./scripts/build.ps1 -clean",
           "qpm qmod build --isLibrary true",
           "pwsh ./scripts/createqmod.ps1 SongDetails -clean"
         ],
-        "copy": [
-          "pwsh ./scripts/copy.ps1"
+        "clean": [
+          "pwsh ./scripts/build.ps1 -clean"
+        ],
+        "log": [
+          "pwsh ./scripts/log.ps1"
         ]
       }
     }
@@ -69,7 +69,7 @@
           "debugSoLink": "https://github.com/Fernthedev/paperlog/releases/download/v1.2.9/debug_libpaperlog.so",
           "overrideSoName": "libpaperlog.so",
           "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v1.2.9/paperlog.qmod",
-          "branchName": "version/v1_2_9"
+          "branchName": "version-v1.2.9"
         }
       },
       "version": "1.2.9"
@@ -125,10 +125,10 @@
     {
       "dependency": {
         "id": "fmt",
-        "versionRange": "=10.0.0",
+        "versionRange": "=9.0.0",
         "additionalData": {
           "headersOnly": true,
-          "branchName": "version/v10_0_0",
+          "branchName": "version-v9.0.0",
           "compileOptions": {
             "systemIncludes": [
               "fmt/include/"
@@ -139,7 +139,7 @@
           }
         }
       },
-      "version": "10.0.0"
+      "version": "9.0.0"
     }
   ]
 }

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -19,7 +19,7 @@
       },
       {
         "id": "beatsaber-hook",
-        "versionRange": "*",
+        "versionRange": "^3.14.0",
         "additionalData": {}
       },
       {
@@ -39,19 +39,19 @@
     ],
     "workspace": {
       "scripts": {
-        "log": [
-          "pwsh ./scripts/log.ps1"
-        ],
-        "qmod": [
-          "pwsh ./scripts/build.ps1 -clean",
-          "qpm-rust qmod build --isLibrary true",
-          "pwsh ./scripts/createqmod.ps1 SongDetails -clean"
-        ],
         "build": [
           "pwsh ./scripts/build.ps1"
         ],
+        "log": [
+          "pwsh ./scripts/log.ps1"
+        ],
         "clean": [
           "pwsh ./scripts/build.ps1 -clean"
+        ],
+        "qmod": [
+          "pwsh ./scripts/build.ps1 -clean",
+          "qpm qmod build --isLibrary true",
+          "pwsh ./scripts/createqmod.ps1 SongDetails -clean"
         ],
         "copy": [
           "pwsh ./scripts/copy.ps1"
@@ -69,7 +69,7 @@
           "debugSoLink": "https://github.com/Fernthedev/paperlog/releases/download/v1.2.9/debug_libpaperlog.so",
           "overrideSoName": "libpaperlog.so",
           "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v1.2.9/paperlog.qmod",
-          "branchName": "version-v1.2.9"
+          "branchName": "version/v1_2_9"
         }
       },
       "version": "1.2.9"
@@ -77,12 +77,12 @@
     {
       "dependency": {
         "id": "libil2cpp",
-        "versionRange": "=0.2.3",
+        "versionRange": "=0.2.5",
         "additionalData": {
           "headersOnly": true
         }
       },
-      "version": "0.2.3"
+      "version": "0.2.5"
     },
     {
       "dependency": {
@@ -125,10 +125,10 @@
     {
       "dependency": {
         "id": "fmt",
-        "versionRange": "=9.0.0",
+        "versionRange": "=10.0.0",
         "additionalData": {
           "headersOnly": true,
-          "branchName": "version-v9.0.0",
+          "branchName": "version/v10_0_0",
           "compileOptions": {
             "systemIncludes": [
               "fmt/include/"
@@ -139,7 +139,7 @@
           }
         }
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     }
   ]
 }

--- a/src/Data/DataGetter.cpp
+++ b/src/Data/DataGetter.cpp
@@ -71,7 +71,7 @@ namespace SongDetailsCache {
 
         auto resp = WebUtil::GetAsync(dataSource, 20, req_headers).get();
         // value is same
-        if (resp.httpCode == 304 && resp.curlStatus == 0 /* CURLE_OK */) {
+        if (resp.httpCode == 304 && resp.curlStatus == CURLE_OK) {
             INFO("Etag was the same, returning nullopt");
             return std::nullopt;
         }

--- a/src/Data/DataGetter.cpp
+++ b/src/Data/DataGetter.cpp
@@ -78,7 +78,7 @@ namespace SongDetailsCache {
 
         if (!resp) { // failed to perform Get operation properly
             std::string log = fmt::format("Failed to dl database: httpCode: {}, curl status: {} ({})", resp.httpCode, curl_easy_strerror(resp.curlStatus), (int)resp.curlStatus);
-            ERROR(log);
+            ERROR("{}", log);
             throw std::runtime_error(log);
         }
 

--- a/src/Data/DataGetter.cpp
+++ b/src/Data/DataGetter.cpp
@@ -77,7 +77,7 @@ namespace SongDetailsCache {
         }
 
         if (!resp) { // failed to perform Get operation properly
-            std::string log = fmt::format("Failed to dl database: httpCode: {}, curl status: {} ({})", resp.httpCode, curl_easy_strerror(resp.curlStatus), resp.curlStatus);
+            std::string log = fmt::format("Failed to dl database: httpCode: {}, curl status: {} ({})", resp.httpCode, curl_easy_strerror(resp.curlStatus), (int)resp.curlStatus);
             ERROR(log);
             throw std::runtime_error(log);
         }

--- a/src/Data/DataGetter.cpp
+++ b/src/Data/DataGetter.cpp
@@ -71,14 +71,17 @@ namespace SongDetailsCache {
 
         auto resp = WebUtil::GetAsync(dataSource, 20, req_headers).get();
         // value is same
-        if (resp.httpCode == 304) {
+        if (resp.httpCode == 304 && resp.curlStatus == 0 /* CURLE_OK */) {
             INFO("Etag was the same, returning nullopt");
             return std::nullopt;
         }
-        if (resp.httpCode != 200) {
-            ERROR("HTTP response code was {}", resp.httpCode);
-            throw std::runtime_error("Failed to dl database");
+
+        if (!resp) { // failed to perform Get operation properly
+            std::string log = fmt::format("Failed to dl database: httpCode: {}, curl status: {} ({})", resp.httpCode, curl_easy_strerror(resp.curlStatus), resp.curlStatus);
+            ERROR(log);
+            throw std::runtime_error(log);
         }
+
 
         DownloadedDatabase downloadedDatabase;
         // assign data source

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -2,9 +2,6 @@
 #include "logging.hpp"
 #include "Data/SongDetailsContainer.hpp"
 
-#include "libcurl/shared/curl.h"
-#include "libcurl/shared/easy.h"
-
 #include <unordered_map>
 #include <sstream>
 #include <iomanip>
@@ -142,7 +139,7 @@ namespace SongDetailsCache {
 			s->append((char*)contents, newLength);
 		} catch(std::bad_alloc &e) {
 			//handle memory problem
-			CRITICAL("Failed to allocate string of size: %lu", newLength);
+			CRITICAL("Failed to allocate string of size: {}", newLength);
 			return 0;
 		}
 		return newLength;
@@ -183,10 +180,10 @@ namespace SongDetailsCache {
 
         curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-        auto res = curl_easy_perform(curl);
+        response.curlStatus = curl_easy_perform(curl);
         /* Check for errors */
-        if (res != CURLE_OK) {
-            ERROR("curl_easy_perform() failed: %u: %s", res, curl_easy_strerror(res));
+        if (response.curlStatus != CURLE_OK) {
+            ERROR("curl_easy_perform() failed: {}: {}", response.curlStatus, curl_easy_strerror(response.curlStatus));
         }
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response.httpCode);
         curl_easy_cleanup(curl);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -183,7 +183,7 @@ namespace SongDetailsCache {
         response.curlStatus = curl_easy_perform(curl);
         /* Check for errors */
         if (response.curlStatus != CURLE_OK) {
-            ERROR("curl_easy_perform() failed: {}: {}", response.curlStatus, curl_easy_strerror(response.curlStatus));
+            ERROR("curl_easy_perform() failed: {}: {}", (int)response.curlStatus, curl_easy_strerror(response.curlStatus));
         }
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response.httpCode);
         curl_easy_cleanup(curl);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,9 @@
 // make modloader happy
 #include "SongDetails.hpp"
 #include "logging.hpp"
+
+#if __has_include("modloader/shared/modloader.hpp")
+#include "modloader/shared/modloader.hpp"
 extern "C" void setup(ModInfo& info) {
     info.id = MOD_ID;
     info.version = VERSION;
@@ -13,3 +16,4 @@ extern "C" void load() {
     songdetails = SongDetailsCache::SongDetails::Init().get();
     INFO("Done loading");
 }
+#endif


### PR DESCRIPTION
 - Adds the internal curl status to the WebResponse struct
 - Checks the internal curl status to decide whether the download was succesful
 - Fixes some logging that was using `%` for formatting instead of `{}`